### PR TITLE
Update dependencies, removing unnecessary one

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,9 @@
     "url": "https://github.com/axa-ch/postcss-pseudoelements/issues"
   },
   "homepage": "https://github.com/axa-ch/postcss-pseudoelements",
-  "dependencies": {
-    "minimatch": "^2.0.1"
-  },
   "devDependencies": {
     "mocha": "^2.0.1",
-    "postcss": "^3.0.5",
-    "should": "^4.3.0"
+    "postcss": ">=3.0.5",
+    "should": "^5.0.0"
   }
 }


### PR DESCRIPTION
Seems like minimatch was not used anymore; and I upgraded should and changed the symbol in front of postcss so that it would consume postcss 4.
