### PR TITLE
Update to PostCSS 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = postcss.plugin('pseudoelements', function(options) {
   var replacements = new RegExp('::(' + selectors.join('|') + ')', 'gi');
 
   return function(css) {
-    css.eachRule(function(rule) {
+    css.walkRules(function(rule) {
       rule.selector = rule.selector.replace(replacements, ':$1');
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-pseudoelements",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "PostCSS plugin to add single-colon CSS 2.1 syntax pseudo selectors (i.e. :before)",
   "main": "index.js",
   "scripts": {
@@ -28,6 +28,6 @@
     "should": "^5.0.0"
   },
   "dependencies": {
-    "postcss": "^4.1.11"
+    "postcss": "^5.0.4"
   }
 }


### PR DESCRIPTION
Updates PostCSS to v5
Updates syntax as `eachRule` was deprecated in favor of `walkRules`
Bumps package version

Thank you for making this plugin. It’s a must-have when I support IE8.
